### PR TITLE
Update Makefile and add CONDA variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PROJECT_NAME = bus_number
 PYTHON_INTERPRETER = python3
 VIRTUALENV = conda
+CONDA_EXE  = /anaconda/bin/conda
 
 ## Install or update Python Dependencies
 requirements: test_environment environment.lock


### PR DESCRIPTION
The `make create_environment' was failing due to an error because the 'CONDA_EXE' variable was not defined.